### PR TITLE
change readme to dart syntax styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ TODO: Add embedding example.
 
 A simple usage example:
 
-    import 'package:comid/comid.dart';
+```dart
+import 'package:comid/comid.dart';
 
-    main() {
-      var editor = new CodeMirror();
-    }
+main() {
+  var editor = new CodeMirror();
+}
+```
 
 ## Features and bugs
 
@@ -22,7 +24,7 @@ Please file feature requests and bugs at the [issue tracker][tracker].
 
 CodeMirror in Dart borrows heavily from the work of Marijn Haverbeke on 
 CodeMirror. It is licensed under the MIT open-source license. Please see the 
-[CodeMirror][site]website for more information.
+[CodeMirror][site] website for more information.
 
 [tracker]: https://code.google.com/p/dart/issues/entry
 [site]: http://codemirror.net/index.html


### PR DESCRIPTION
- use Dart syntax styling on the readme example

@stevemessick 
