### PR TITLE
Swap args to hint fn

### DIFF
--- a/lib/addon/edit/show_hint.dart
+++ b/lib/addon/edit/show_hint.dart
@@ -132,9 +132,9 @@ class Completion {
       this.finishUpdate(this.options.hint(this.cm, this.options), first);
     } else {
       var myTick = ++this.tick;
-      this.options.hint(this.cm, (data) {
+      this.options.hint(this.cm, this.options, (data) {
         if (tick == myTick) finishUpdate(data, first);
-      }, this.options);
+      });
     }
   }
 


### PR DESCRIPTION
I forgot to swap args in one call to the hint computer. I swapped them during translation to make it easier to deal with optional args, and because this order is easier to read.
@devoncarew 
